### PR TITLE
Deprecate Python 3.8

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: ">=3.9"
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "cordage"
 dynamic = ["version"]
 description = "Computational research data management tool"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = "MIT"
 keywords = []
 authors = [
@@ -12,10 +12,11 @@ authors = [
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
@@ -74,7 +75,7 @@ serve-docs = [
 ]
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11"]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 [tool.hatch.envs.lint]
 detached = true
@@ -102,7 +103,7 @@ all = [
 # --- LINTING ---
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 99
 
 [tool.ruff.lint]

--- a/src/cordage/__init__.py
+++ b/src/cordage/__init__.py
@@ -2,7 +2,7 @@ import logging
 import sys
 from dataclasses import replace
 from os import PathLike
-from typing import Callable, Dict, List, Optional, Type, Union
+from typing import Callable, Optional, Union
 
 import cordage.exceptions
 from cordage.context import FunctionContext
@@ -14,11 +14,11 @@ logger = logging.getLogger("cordage")
 
 def run(
     func: Callable,
-    args: Optional[List[str]] = None,
+    args: Optional[list[str]] = None,
     *,
     description: Optional[str] = None,
-    config_cls: Optional[Type] = None,
-    global_config: Union[PathLike, Dict, GlobalConfig, None] = None,
+    config_cls: Optional[type] = None,
+    global_config: Union[PathLike, dict, GlobalConfig, None] = None,
     **kw,
 ) -> Experiment:
     try:

--- a/src/cordage/context.py
+++ b/src/cordage/context.py
@@ -2,18 +2,15 @@ import argparse
 import dataclasses
 import inspect
 import sys
+from collections.abc import Mapping
 from contextlib import contextmanager
 from pathlib import Path
 from typing import (
     Any,
     Callable,
     ClassVar,
-    Dict,
-    List,
     Literal,
-    Mapping,
     Optional,
-    Type,
     Union,
     get_args,
     get_origin,
@@ -38,7 +35,7 @@ SUPPORTED_PRIMITIVES = (int, bool, str, float, Path)
 
 
 class Singleton(type):
-    _instances: ClassVar[Dict[Type, Any]] = {}
+    _instances: ClassVar[dict[type, Any]] = {}
 
     def __call__(cls, *args, **kwargs):
         if cls not in cls._instances:
@@ -54,7 +51,7 @@ class ExperimentStack(metaclass=Singleton):
     """
 
     def __init__(self):
-        self.running: List[Experiment] = []
+        self.running: list[Experiment] = []
 
     def push(self, experiment: Experiment):
         """Push a new experiment on the stack."""
@@ -127,7 +124,7 @@ class FunctionContext:
         func: Callable,  # expects a dataclass
         global_config: GlobalConfig,
         description: Optional[str] = None,
-        config_cls: Optional[Type[ConfigClass]] = None,
+        config_cls: Optional[type[ConfigClass]] = None,
     ):
         self.global_config = global_config
         self.set_function(func)
@@ -145,7 +142,7 @@ class FunctionContext:
         else:
             self.description = description
 
-    def set_config_cls(self, config_cls: Optional[Type] = None):
+    def set_config_cls(self, config_cls: Optional[type] = None):
         # derive configuration class
         if config_cls is None:
             self.main_config_cls = self.func_parameters[
@@ -307,7 +304,7 @@ class FunctionContext:
                 f"--{arg_name}", type=arg_type, default=MISSING, help=help, **kw
             )
 
-    def add_arguments_to_parser(self, config_cls: Type, prefix: Optional[str] = None):
+    def add_arguments_to_parser(self, config_cls: type, prefix: Optional[str] = None):
         """Add all fields in the (nested) config class to the parser.
 
         Recursively iterate over the fields adding arguments to the
@@ -342,12 +339,12 @@ class FunctionContext:
 
             self._add_argument_to_parser(arg_name, field.type, help=help_text)
 
-    def remove_missing_values(self, data: Mapping) -> Dict[str, Any]:
+    def remove_missing_values(self, data: Mapping) -> dict[str, Any]:
         return {k: v for k, v in data.items() if v is not MISSING}
 
     def construct_func_kwargs(self, trial: Trial):
         # construct arguments for the passed callable
-        func_kw: Dict[str, Any] = {}
+        func_kw: dict[str, Any] = {}
 
         # check if any other parameters are expected which can be
         # resolved
@@ -374,7 +371,7 @@ class FunctionContext:
 
         return func_kw
 
-    def parse_args(self, args: Optional[List[str]] = None) -> Experiment:
+    def parse_args(self, args: Optional[list[str]] = None) -> Experiment:
         """Parse the command line arguments.
 
         Args:

--- a/src/cordage/global_config.py
+++ b/src/cordage/global_config.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from os import PathLike
 from pathlib import Path
-from typing import Dict, Union
+from typing import Union
 
 from cordage.util import from_dict as config_from_dict
 from cordage.util import from_file as config_from_file
@@ -61,7 +61,7 @@ class GlobalConfig:
         )
 
     @classmethod
-    def resolve(cls, global_config: Union[str, PathLike, Dict, "GlobalConfig", None]):
+    def resolve(cls, global_config: Union[str, PathLike, dict, "GlobalConfig", None]):
         # Dictionary: create configuration based on these values
         if isinstance(global_config, dict):
             logger.debug("Creating global from dictionary.")

--- a/tests/config_classes.py
+++ b/tests/config_classes.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal, Optional, Tuple
+from typing import Literal, Optional
 
 
 @dataclass
@@ -55,7 +55,7 @@ class LongConfig:
     e: Literal["a", "b", "c"] = "a"
     f: bool = False
     g: Optional[int] = None
-    h: Tuple[str, ...] = ("a", "b")
-    i: Tuple[str, str] = ("a", "b")
-    j: Tuple[str, int, float] = ("a", 1, 1.0)
+    h: tuple[str, ...] = ("a", "b")
+    i: tuple[str, str] = ("a", "b")
+    j: tuple[str, int, float] = ("a", 1, 1.0)
     k: Optional[int] = None

--- a/tests/test_misc_functionality.py
+++ b/tests/test_misc_functionality.py
@@ -1,5 +1,4 @@
 from time import sleep
-from typing import List
 
 import pytest
 from config_classes import SimpleConfig
@@ -34,7 +33,7 @@ def test_timing(global_config):
 
 @pytest.mark.timeout(60)
 def test_trial_id_collision(global_config):
-    trial_store: List[cordage.Trial] = []
+    trial_store: list[cordage.Trial] = []
 
     def func(config: SimpleConfig, cordage_trial: cordage.Trial, trial_store=trial_store):  # noqa: ARG001
         trial_store.append(cordage_trial)

--- a/tests/test_result_storing.py
+++ b/tests/test_result_storing.py
@@ -1,6 +1,5 @@
 import re
 from pathlib import Path
-from typing import List
 
 from config_classes import SimpleConfig as Config
 
@@ -59,7 +58,7 @@ def test_path_return_value(global_config):
 
 
 def test_float_return_value(global_config):
-    trial_store: List[cordage.Trial] = []
+    trial_store: list[cordage.Trial] = []
 
     def func(config: Config, cordage_trial, trial_store=trial_store):  # noqa: ARG001
         return 0.0

--- a/tests/test_series_creation.py
+++ b/tests/test_series_creation.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import pytest
 from config_classes import NestedConfig as Config
 
@@ -8,7 +6,7 @@ from cordage import Series
 
 
 def test_trial_series_list(global_config, resources_path):
-    trial_store: List[cordage.Trial] = []
+    trial_store: list[cordage.Trial] = []
 
     def func(config: Config, cordage_trial: cordage.Trial, trial_store=trial_store):  # noqa: ARG001
         trial_store.append(cordage_trial)
@@ -41,7 +39,7 @@ def test_trial_series_list(global_config, resources_path):
 
 @pytest.mark.parametrize("letter", "abc")
 def test_more_trial_series(global_config, resources_path, letter):
-    trial_store: List[cordage.Trial] = []
+    trial_store: list[cordage.Trial] = []
 
     def func(config: Config, cordage_trial: cordage.Trial, trial_store=trial_store):  # noqa: ARG001
         trial_store.append(cordage_trial)
@@ -80,7 +78,7 @@ def test_invalid_trial_series(global_config, resources_path):
 
 
 def test_trial_skipping(global_config, resources_path):
-    trial_store: List[cordage.Trial] = []
+    trial_store: list[cordage.Trial] = []
 
     def func(config: Config, cordage_trial: cordage.Trial, trial_store=trial_store):  # noqa: ARG001
         trial_store.append(cordage_trial)


### PR DESCRIPTION
Python 3.8 reached its [end of life](https://endoflife.date/python) >1 month ago. Accordingly, we end its support in this project. Python 3.9 is now the minimum version.