### PR TITLE
Allow Execution of a Single Trial in a Series (via the CLI)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 detached = true
 dependencies = [
   "mypy>=1.7.0",
-  "ruff>=0.8.1",
+  "ruff>=0.9.6",
 ]
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive {args:src/cordage tests}"

--- a/src/cordage/context.py
+++ b/src/cordage/context.py
@@ -210,6 +210,15 @@ class FunctionContext:
             dest=self.global_config._series_skip_key,
         )
 
+        self.argument_parser.add_argument(
+            "--series-trial",
+            type=int,
+            metavar="I",
+            help="Execute trial with index I.",
+            default=MISSING,
+            dest=self.global_config._series_trial_key,
+        )
+
         if not self.global_config.config_only:
             self.argument_parser.add_argument(
                 "--cordage-comment",
@@ -439,6 +448,7 @@ class FunctionContext:
         # series skip might be given via the command line
         # ("--series-skip <n>") or a config file "__series-skip__"
         series_kw["series_skip"] = argument_data.pop(self.global_config._series_skip_key, None)
+        series_kw["series_trial"] = argument_data.pop(self.global_config._series_trial_key, None)
         series_kw["base_config"] = argument_data
         series_kw["config_cls"] = self.main_config_cls
 
@@ -463,12 +473,18 @@ class FunctionContext:
         base_config=None,
         series_spec=None,
         series_skip: Optional[int] = None,
+        series_trial: Optional[int] = None,
         comment: Optional[str] = None,
     ) -> Experiment:
         _usage = "Either pass `config` or `base_config` and `series_spec`"
 
         if config is not None:
-            assert base_config is None and series_spec is None and series_skip is None, _usage
+            assert (
+                base_config is None
+                and series_spec is None
+                and series_skip is None
+                and series_trial is None
+            ), _usage
 
             trial: Trial = Trial(
                 function=self.func_name,
@@ -490,6 +506,7 @@ class FunctionContext:
                 global_config=self.global_config,
                 series_spec=series_spec,
                 series_skip=series_skip,
+                series_trial=series_trial,
                 additional_info={"description": self.description},
             )
             series.comment = comment

--- a/src/cordage/context.py
+++ b/src/cordage/context.py
@@ -358,9 +358,9 @@ class FunctionContext:
         # check if any other parameters are expected which can be
         # resolved
         for name, param in self.func_parameters.items():
-            assert (
-                param.kind != param.POSITIONAL_ONLY
-            ), "Cordage currently does not support positional only parameters."
+            assert param.kind != param.POSITIONAL_ONLY, (
+                "Cordage currently does not support positional only parameters."
+            )
 
             if name == self.global_config.param_name_config:
                 # pass the configuration

--- a/src/cordage/experiment.py
+++ b/src/cordage/experiment.py
@@ -128,9 +128,9 @@ class Experiment(Annotatable):
 
     def load_data(self):
         """Synchronize to existing output directory."""
-        assert (
-            self.metadata.output_dir is not None
-        ), f"Cannot synchronize a {self.__class__.__name__} which has no `output_dir`."
+        assert self.metadata.output_dir is not None, (
+            f"Cannot synchronize a {self.__class__.__name__} which has no `output_dir`."
+        )
 
         if self.metadata.output_dir.exists():
             metadata = self.load_metadata(self.metadata.output_dir)

--- a/src/cordage/global_config.py
+++ b/src/cordage/global_config.py
@@ -26,6 +26,7 @@ class GlobalConfig:
 
     _series_spec_key = "__series__"
     _series_skip_key = "__series-skip__"
+    _series_trial_key = "__series-trial__"
     _experiment_comment_key = "__cordage-comment__"
     _output_dir_key = "__output-dir__"
 

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -60,7 +60,7 @@ def test_trial_series_loading(global_config, resources_path, capsys):
     i = 1
 
     for captured_line in captured.err.strip().split("\n"):
-        assert f"Trial with alpha.b=b{i-1}" not in captured_line
+        assert f"Trial with alpha.b=b{i - 1}" not in captured_line
 
         if f"Trial with alpha.b=b{i}" in captured_line:
             i += 1
@@ -75,8 +75,8 @@ def test_trial_series_loading(global_config, resources_path, capsys):
 
         config = trial.metadata.configuration
 
-        assert config["alpha"]["b"] == f"b{i+1}"
-        assert trial.has_tag(f"b{i+1}")
+        assert config["alpha"]["b"] == f"b{i + 1}"
+        assert trial.has_tag(f"b{i + 1}")
 
         assert isinstance(trial.metadata.start_time, datetime)
 
@@ -87,7 +87,7 @@ def test_trial_series_loading(global_config, resources_path, capsys):
             log_lines = list(fp)
 
             for j in range(3):
-                expected_log_partial = f"Trial with alpha.b=b{j+1}"
+                expected_log_partial = f"Trial with alpha.b=b{j + 1}"
 
                 if i == j:
                     assert any(expected_log_partial in line for line in log_lines)
@@ -119,4 +119,4 @@ def test_trial_series_loading_with_config_class(global_config, resources_path):
     # dictionaries
     for i, trial in enumerate(series):
         assert isinstance(trial.config, NestedConfig)
-        assert trial.config.alpha.b == f"b{i+1}"
+        assert trial.config.alpha.b == f"b{i + 1}"

--- a/tests/test_series_creation.py
+++ b/tests/test_series_creation.py
@@ -101,3 +101,24 @@ def test_trial_skipping(global_config, resources_path):
 
     for i, trial in enumerate(trial_store, start=1):
         assert trial.output_dir == global_config.base_output_dir / "experiment" / str(i)
+
+
+def test_single_trial_execution(global_config, resources_path):
+    trial_store: list[cordage.Trial] = []
+
+    def func(config: Config, cordage_trial: cordage.Trial, trial_store=trial_store):  # noqa: ARG001
+        trial_store.append(cordage_trial)
+
+    config_file = resources_path / "series_list.yml"
+
+    cordage.run(func, args=[str(config_file), "--series-trial", "1"], global_config=global_config)
+
+    assert len(trial_store) == 1
+
+    assert trial_store[0].metadata.additional_info["trial_index"] == 1
+    assert trial_store[0].config.alpha.a == 2
+    assert trial_store[0].config.alpha.b == "b2"
+    assert trial_store[0].config.beta.a == "c2"
+
+    for i, trial in enumerate(trial_store, start=1):
+        assert trial.output_dir == global_config.base_output_dir / "experiment" / str(i)


### PR DESCRIPTION
This has multiple benefits:
1. Enables splitting up the series execution across multiple parallel process (though the series metadata may be corrupted this way.
2. Enables execution of a single trial for test purposes (without the need to rewrite the config).
3. Enables continuation/rerunning single trials where issues occurred.