### PR TITLE
Dropping support for Python 3.9

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,19 +17,38 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
+    - uses: actions/checkout@v6
+
+    - name: Set up Python ${{ matrix.python-version }}
+      id: setup-python
+      uses: actions/setup-python@v6
       with:
-        python-version: '3.11'
-        cache: 'pip'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip 
-        pip install hatch
+        python-version: 3.10
+
+    - name: Install Hatch
+      uses: pypa/hatch@install
+
+    # Set up caching of hatch's virtual environment
+    - name: Set up hatch environment cache
+      if: runner.os == 'Linux'
+      uses: "actions/cache@v5"
+      with:
+        path: .venv/
+        key: "hatch-env-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('pyproject.toml') }}"
+        restore-keys: "hatch-env-${{ steps.setup-python.outputs.python-version }}-"
+
+    - name: Configure hatch
+      run: hatch config set dirs.env.virtual ".venv"
+
+    - name: Lint
+      run: hatch run lint:fmt
+    - name: Type Checking
+      run: hatch run lint:typing-github
+    - name: Tests
+      run: hatch run test:test
+
     - name: Build package
       run: hatch build
-    - name: Test package
-      run: hatch run test
+
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,28 +23,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.13"]
+        python-version: ["3.10", "3.12", "3.14"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
+
     - name: Set up Python ${{ matrix.python-version }}
       id: setup-python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
+        # No cache needed, since packages are managed in the hatch virtual environment
         python-version: ${{ matrix.python-version }}
-        cache: "pip"
+
+    - name: Install Hatch
+      uses: pypa/hatch@install
+
     # Set up caching of hatch's virtual environment
     - name: Set up hatch environment cache
       if: runner.os == 'Linux'
-      uses: "actions/cache@v4"
+      uses: "actions/cache@v5"
       with:
         path: .venv/
         key: "hatch-env-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('pyproject.toml') }}"
         restore-keys: "hatch-env-${{ steps.setup-python.outputs.python-version }}-"
     # Install hatch and set the venv-location
-    - name: Install hatch
-      run: pipx install hatch; hatch config set dirs.env.virtual ".venv"
+    - name: Configure hatch
+      run: hatch config set dirs.env.virtual ".venv"
     - name: Lint
-      run: hatch run lint:all
+      run: hatch run lint:fmt
+    - name: Type Checking
+      run: hatch run lint:typing-github
     - name: Tests
       run: hatch run +py=${{ matrix.python-version }} all:test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "cordage"
 dynamic = ["version"]
 description = "Computational research data management tool"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "MIT"
 keywords = []
 authors = [
@@ -75,7 +75,7 @@ serve-docs = [
 ]
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
+python = ["3.10", "3.12", "3.14"]
 
 [tool.hatch.envs.lint]
 detached = true
@@ -103,7 +103,7 @@ all = [
 # --- LINTING ---
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 line-length = 99
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,11 +80,12 @@ python = ["3.10", "3.12", "3.14"]
 [tool.hatch.envs.lint]
 detached = true
 dependencies = [
-  "mypy>=1.7.0",
+  "ty>=0.0.17",
   "ruff>=0.12.8",
 ]
 [tool.hatch.envs.lint.scripts]
-typing = "mypy --install-types --non-interactive {args:src/cordage tests}"
+typing = "ty check {args:src/cordage tests}"
+typing-github = "ty check {args:src/cordage tests} --output-format github"
 style = [
   "ruff format --check {args:.}",
   "ruff check {args:.}",
@@ -169,10 +170,8 @@ ban-relative-imports = "all"
 
 # --- TYPE CHECKING ---
 
-[tool.mypy]
-ignore_missing_imports = true
-check_untyped_defs = true
-
+[tool.ty]
+rules.unresolved-import = "ignore"
 
 # --- TEST COVERAGE ---
 

--- a/src/cordage/__init__.py
+++ b/src/cordage/__init__.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from dataclasses import replace
 from os import PathLike
 
-import cordage.exceptions
+from cordage import exceptions
 from cordage.context import FunctionContext
 from cordage.experiment import Experiment, Metadata, Series, Status, Trial
 from cordage.global_config import GlobalConfig
@@ -32,7 +32,7 @@ def run(
         experiment = context.parse_args(args)
         context.execute(experiment)
         return experiment
-    except cordage.exceptions.CordageError as e:
+    except exceptions.CordageError as e:
         if _global_config.catch_exception:
             logger.critical(str(e))
             sys.exit(1)
@@ -48,5 +48,6 @@ __all__ = [
     "Series",
     "Status",
     "Trial",
+    "exceptions",
     "run",
 ]

--- a/src/cordage/__init__.py
+++ b/src/cordage/__init__.py
@@ -1,8 +1,8 @@
 import logging
 import sys
+from collections.abc import Callable
 from dataclasses import replace
 from os import PathLike
-from typing import Callable, Optional, Union
 
 import cordage.exceptions
 from cordage.context import FunctionContext
@@ -14,11 +14,11 @@ logger = logging.getLogger("cordage")
 
 def run(
     func: Callable,
-    args: Optional[list[str]] = None,
+    args: list[str] | None = None,
     *,
-    description: Optional[str] = None,
-    config_cls: Optional[type] = None,
-    global_config: Union[PathLike, dict, GlobalConfig, None] = None,
+    description: str | None = None,
+    config_cls: type | None = None,
+    global_config: PathLike | dict | GlobalConfig | None = None,
     **kw,
 ) -> Experiment:
     try:

--- a/src/cordage/context.py
+++ b/src/cordage/context.py
@@ -222,7 +222,7 @@ class FunctionContext(TrialIndexMixin):
     def set_function(self, func: Callable):
         self._func = func
         self._func_parameters = inspect.signature(func).parameters
-        self._func_name = self.func.__name__
+        self._func_name = getattr(self.func, "__name__", "unnamed-function")
 
         if self.global_config.param_name_config not in self.func_parameters:
             msg = (
@@ -465,12 +465,7 @@ class FunctionContext(TrialIndexMixin):
         conf_file_comment: str | None = None
         cli_series_comment: str | None = None
 
-        series_kw = {
-            "function": self.func_name,
-            "global_config": self.global_config,
-            "status": Status.PENDING,
-            "additional_info": {"description": self.description, "parsed_arguments": args},
-        }
+        series_kw = {}
 
         if not self.global_config.config_only:
             cli_series_comment = argument_data.pop(
@@ -480,14 +475,15 @@ class FunctionContext(TrialIndexMixin):
 
         config_path = argument_data.pop(".", None)
 
-        argument_data = nest_items(argument_data.items())
+        argument_data: dict[str, Any] | None = nest_items(argument_data.items())
+        series_spec: list[dict] | dict[str, list] | None
 
         if config_path is not None:
             new_conf_data = read_dict_from_file(config_path)
 
             new_conf_data = nest_items(new_conf_data.items())
 
-            series_kw["series_spec"] = new_conf_data.pop(self.global_config._series_spec_key, None)
+            series_spec = new_conf_data.pop(self.global_config._series_spec_key, None)
 
             nested_update(new_conf_data, argument_data)
 
@@ -501,15 +497,27 @@ class FunctionContext(TrialIndexMixin):
                     self.global_config._experiment_comment_key, None
                 )
         else:
-            series_kw["series_spec"] = None
+            series_spec = None
 
         # series skip might be given via the command line
         # ("--series-skip <n>") or a config file "__series-skip__"
-        series_kw["trial_indices"] = argument_data.pop(self.global_config._trial_indices_key, None)
-        series_kw["base_config"] = argument_data
-        series_kw["config_cls"] = self.main_config_cls
+        trial_indices: TrialIndices | None = argument_data.pop(
+            self.global_config._trial_indices_key, None
+        )
+        base_config: dict[str, Any] | None = argument_data
+        config_cls = self.main_config_cls
 
-        series: Series = Series(**series_kw)
+        series: Series = Series(
+            series_spec=series_spec,
+            trial_indices=trial_indices,
+            base_config=base_config,
+            config_cls=config_cls,
+            function=self.func_name,
+            global_config=self.global_config,
+            status=Status.PENDING,
+            additional_info={"description": self.description, "parsed_arguments": args},
+            **series_kw,
+        )
 
         if not self.global_config.config_only:
             if cli_series_comment is not None and conf_file_comment is not None:

--- a/src/cordage/context.py
+++ b/src/cordage/context.py
@@ -3,16 +3,14 @@ import dataclasses
 import inspect
 import re
 import sys
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from contextlib import contextmanager
 from enum import Enum
 from pathlib import Path
 from typing import (
     Any,
-    Callable,
     ClassVar,
     Literal,
-    Optional,
     Union,
     get_args,
     get_origin,
@@ -71,7 +69,7 @@ class ExperimentStack(metaclass=Singleton):
         """Pop the currently running experiment from the stack."""
         return self.running.pop()
 
-    def peek(self) -> Optional[Experiment]:
+    def peek(self) -> Experiment | None:
         """Get the currently active experiment from the stack.
 
         If the stack is empty, None is returned.
@@ -81,7 +79,7 @@ class ExperimentStack(metaclass=Singleton):
         else:
             return None
 
-    def peek_dir(self) -> Optional[Path]:
+    def peek_dir(self) -> Path | None:
         """Get the output_dir of the currently running experiment.
 
         If the stack is empty, None is returned.
@@ -127,7 +125,7 @@ class TrialIndexMixin:
     def match_trial_range_entry(
         self,
         value,
-    ) -> Union[int, tuple[Optional[int], Optional[int]]]:
+    ) -> int | tuple[int | None, int | None]:
         match = self.trial_index_pattern.match(value.strip())
         if not match:
             msg = (
@@ -172,8 +170,8 @@ class FunctionContext(TrialIndexMixin):
         self,
         func: Callable,  # expects a dataclass
         global_config: GlobalConfig,
-        description: Optional[str] = None,
-        config_cls: Optional[type[ConfigClass]] = None,
+        description: str | None = None,
+        config_cls: type[ConfigClass] | None = None,
     ):
         self.global_config = global_config
         self.set_function(func)
@@ -181,7 +179,7 @@ class FunctionContext(TrialIndexMixin):
         self.set_description(description)
         self.construct_argument_parser()
 
-    def set_description(self, description: Optional[str] = None):
+    def set_description(self, description: str | None = None):
         if description is None:
             if self.func.__doc__ is not None:
                 self.description = parse_docstring(self.func.__doc__).short_description
@@ -191,7 +189,7 @@ class FunctionContext(TrialIndexMixin):
         else:
             self.description = description
 
-    def set_config_cls(self, config_cls: Optional[type] = None):
+    def set_config_cls(self, config_cls: type | None = None):
         # derive configuration class
         if config_cls is None:
             self.main_config_cls = self.func_parameters[
@@ -357,7 +355,7 @@ class FunctionContext(TrialIndexMixin):
                 f"--{arg_name}", type=arg_type, default=MISSING, help=help, **kw
             )
 
-        elif issubclass(arg_type, Enum):
+        elif isinstance(arg_type, type) and issubclass(arg_type, Enum):
             self.arg_group_config.add_argument(
                 f"--{arg_name}", type=arg_type, default=MISSING, help=help, choices=list(arg_type)
             )
@@ -365,7 +363,7 @@ class FunctionContext(TrialIndexMixin):
         else:
             logger.debug("Ignoring field %s: Type %s not supported.", arg_name, str(arg_type))
 
-    def add_arguments_to_parser(self, config_cls: type, prefix: Optional[str] = None):
+    def add_arguments_to_parser(self, config_cls: type, prefix: str | None = None):
         """Add all fields in the (nested) config class to the parser.
 
         Recursively iterate over the fields adding arguments to the
@@ -432,7 +430,7 @@ class FunctionContext(TrialIndexMixin):
 
         return func_kw
 
-    def parse_args(self, args: Optional[list[str]] = None) -> Experiment:
+    def parse_args(self, args: list[str] | None = None) -> Experiment:
         """Parse the command line arguments.
 
         Args:
@@ -464,8 +462,8 @@ class FunctionContext(TrialIndexMixin):
 
         argument_data = self.remove_missing_values(argument_data)
 
-        conf_file_comment: Optional[str] = None
-        cli_series_comment: Optional[str] = None
+        conf_file_comment: str | None = None
+        cli_series_comment: str | None = None
 
         series_kw = {
             "function": self.func_name,
@@ -531,8 +529,8 @@ class FunctionContext(TrialIndexMixin):
         config=None,
         base_config=None,
         series_spec=None,
-        trial_indices: Optional[TrialIndices] = None,
-        comment: Optional[str] = None,
+        trial_indices: TrialIndices | None = None,
+        comment: str | None = None,
     ) -> Experiment:
         _usage = "Either pass `config` or `base_config` and `series_spec`"
 

--- a/src/cordage/experiment.py
+++ b/src/cordage/experiment.py
@@ -13,9 +13,7 @@ from typing import (
     Any,
     Generic,
     Literal,
-    Optional,
     TypeVar,
-    Union,
     overload,
 )
 
@@ -48,7 +46,7 @@ ConfigClass = TypeVar("ConfigClass", bound="DataclassInstance")
 
 
 class Experiment(Annotatable):
-    def __init__(self, *args, config_cls: Optional[type] = None, **kwargs):
+    def __init__(self, *args, config_cls: type | None = None, **kwargs):
         super().__init__(*args, **kwargs)
 
         self.config_cls = config_cls
@@ -158,7 +156,7 @@ class Experiment(Annotatable):
         cls,
         path: PathLike,
         *,
-        config_cls: Optional[type[ConfigClass]] = None,
+        config_cls: type[ConfigClass] | None = None,
         load_series_trials: bool = True,
     ):
         metadata: Metadata = cls.load_metadata(path)
@@ -180,7 +178,7 @@ class Experiment(Annotatable):
 
     @classmethod
     def all_from_path(
-        cls, results_path: Union[str, PathLike], *, skip_hidden: bool = True
+        cls, results_path: str | PathLike, *, skip_hidden: bool = True
     ) -> list["Experiment"]:
         """Load all experiments from the results_path."""
         results_path = Path(results_path)
@@ -304,9 +302,9 @@ class Experiment(Annotatable):
 class Trial(Experiment, Generic[ConfigClass]):
     def __init__(
         self,
-        metadata: Optional[Metadata] = None,
+        metadata: Metadata | None = None,
         /,
-        config: Optional[dict[str, Any]] = None,
+        config: dict[str, Any] | None = None,
         config_cls=None,
         **kw,
     ):
@@ -319,7 +317,7 @@ class Trial(Experiment, Generic[ConfigClass]):
         else:
             super().__init__(configuration=config, config_cls=config_cls, **kw)
 
-        self._config: Optional[ConfigClass] = None
+        self._config: ConfigClass | None = None
 
     @property
     def config(self) -> ConfigClass:
@@ -365,11 +363,11 @@ class Series(Generic[ConfigClass], Experiment):
 
     def __init__(
         self,
-        metadata: Optional[Metadata] = None,
+        metadata: Metadata | None = None,
         /,
-        base_config: Optional[dict[str, Any]] = None,
-        series_spec: Union[list[dict], dict[str, list], None] = None,
-        trial_indices: Optional[TrialIndices] = None,
+        base_config: dict[str, Any] | None = None,
+        series_spec: list[dict] | dict[str, list] | None = None,
+        trial_indices: TrialIndices | None = None,
         config_cls=None,
         **kw,
     ):
@@ -428,12 +426,12 @@ class Series(Generic[ConfigClass], Experiment):
         return self.metadata.configuration["base_config"]
 
     @property
-    def series_spec(self) -> Union[list[dict], dict[str, list], None]:
+    def series_spec(self) -> list[dict] | dict[str, list] | None:
         return self.metadata.configuration["series_spec"]
 
     @property
     def series_skip(self) -> int:
-        skip: Optional[int] = self.metadata.configuration.get("series_skip", None)
+        skip: int | None = self.metadata.configuration.get("series_skip", None)
 
         if skip is None:
             return 0
@@ -466,9 +464,7 @@ class Series(Generic[ConfigClass], Experiment):
     @overload
     def get_changing_fields(self, sep: str) -> set[str]: ...
 
-    def get_changing_fields(
-        self, sep: Optional[str] = None
-    ) -> Union[set[tuple[Any, ...]], set[str]]:
+    def get_changing_fields(self, sep: str | None = None) -> set[tuple[Any, ...]] | set[str]:
         keys: set = set()
 
         if isinstance(self.series_spec, list):
@@ -486,10 +482,10 @@ class Series(Generic[ConfigClass], Experiment):
         if isinstance(self.series_spec, list):
             yield from self.series_spec
         elif isinstance(self.series_spec, dict):
-            keys, values = zip(*flattened_items(self.series_spec, sep="."))
+            keys, values = zip(*flattened_items(self.series_spec, sep="."), strict=False)
 
             for update_values in product(*values):
-                yield nest_items(zip(keys, update_values))
+                yield nest_items(zip(keys, update_values, strict=False))
         else:
             yield {}
 
@@ -571,12 +567,12 @@ class Series(Generic[ConfigClass], Experiment):
         if include_skipped:
             return list(range(1, len(self) + 1))
 
-        entries: Optional[TrialIndices] = self.metadata.configuration.get("trial_indices", None)
+        entries: TrialIndices | None = self.metadata.configuration.get("trial_indices", None)
 
         if not entries:
             return list(range(1, len(self) + 1))
 
-        indices: list[Union[Iterable[int]]] = []
+        indices: list[Iterable[int]] = []
 
         entry: TrialIndicesEntry
         for entry in entries:

--- a/src/cordage/experiment.py
+++ b/src/cordage/experiment.py
@@ -1,6 +1,6 @@
 import logging
 import shutil
-from collections.abc import Generator, Iterable
+from collections.abc import Generator, Iterable, Iterator
 from copy import deepcopy
 from datetime import datetime, timezone
 from itertools import chain, count, product
@@ -22,7 +22,7 @@ from dacite import DaciteError
 try:
     import colorlog
 except ImportError:
-    colorlog = None  # type: ignore
+    colorlog = None
 
 import typing
 
@@ -49,7 +49,7 @@ class Experiment(Annotatable):
     def __init__(self, *args, config_cls: type | None = None, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.config_cls = config_cls
+        self.config_cls: type[ConfigClass] | None = config_cls
         self.log_handlers: list[logging.Handler] = []
 
     def __repr__(self):
@@ -59,7 +59,7 @@ class Experiment(Annotatable):
             return f"{self.__class__.__name__} (status: {self.status})"
 
     @property
-    def log_path(self):
+    def log_path(self) -> Path:
         return self.output_dir / self.global_config.logging_filename
 
     @property
@@ -169,6 +169,7 @@ class Experiment(Annotatable):
             experiment = Series(metadata, config_cls=config_cls)
             if load_series_trials:
                 for trial in experiment:
+                    assert trial.metadata.output_dir is not None
                     if trial.metadata.output_dir.exists():
                         trial.load_data()
 
@@ -305,7 +306,7 @@ class Trial(Experiment, Generic[ConfigClass]):
         metadata: Metadata | None = None,
         /,
         config: dict[str, Any] | None = None,
-        config_cls=None,
+        config_cls: type[ConfigClass] | None = None,
         **kw,
     ):
         if metadata is not None:
@@ -353,9 +354,8 @@ class Trial(Experiment, Generic[ConfigClass]):
             if output_dir_type is not None:
                 self.metadata.configuration["output_dir"] = path
 
-                # Config has attribute output_dir, mypy does not know it
                 if self._config is not None:
-                    self.config.output_dir = output_dir_type(path)  # type: ignore
+                    self.config.output_dir = output_dir_type(path)
 
 
 class Series(Generic[ConfigClass], Experiment):
@@ -453,9 +453,9 @@ class Series(Generic[ConfigClass], Experiment):
             super().__enter__()
         # else: do nothing
 
-    def __exit__(self, *args):
+    def __exit__(self, *args, **kw):
         if not self.is_singular:
-            super().__exit__(*args)
+            super().__exit__(*args, **kw)
         # else: do nothing
 
     @overload
@@ -560,8 +560,8 @@ class Series(Generic[ConfigClass], Experiment):
                 )
                 self.trials.append(trial)
 
-    def __iter__(self):
-        return self.get_all_trials(include_skipped=False)
+    def __iter__(self) -> Iterator[Trial]:
+        return iter(self.get_all_trials(include_skipped=False))
 
     def get_effective_indices(self, *, include_skipped=False) -> list[int]:
         if include_skipped:

--- a/src/cordage/global_config.py
+++ b/src/cordage/global_config.py
@@ -72,7 +72,7 @@ class GlobalConfig:
             return config_from_dict(cls, global_config)
 
         # Path: load configuration file from this path
-        elif isinstance(global_config, (str, Path)):
+        elif isinstance(global_config, str | Path):
             global_config = Path(global_config)
             if not global_config.exists():
                 msg = f"Given cordage configuration path ({global_config}) does not exist."

--- a/src/cordage/metadata.py
+++ b/src/cordage/metadata.py
@@ -14,7 +14,7 @@ from typing import (
 try:
     import colorlog
 except ImportError:
-    colorlog = None  # type: ignore
+    colorlog = None
 
 import typing
 from enum import Enum

--- a/src/cordage/metadata.py
+++ b/src/cordage/metadata.py
@@ -8,7 +8,6 @@ from os import PathLike
 from pathlib import Path
 from typing import (
     Any,
-    Optional,
     TypeVar,
 )
 
@@ -60,15 +59,15 @@ class Metadata:
 
     configuration: dict[str, Any]
 
-    output_dir: Optional[Path] = None
+    output_dir: Path | None = None
     status: Status = Status.UNKOWN
 
-    start_time: Optional[datetime] = None
-    end_time: Optional[datetime] = None
+    start_time: datetime | None = None
+    end_time: datetime | None = None
 
     result: Any = None
 
-    parent_dir: Optional[Path] = None
+    parent_dir: Path | None = None
 
     additional_info: dict = field(default_factory=dict)
 
@@ -96,9 +95,9 @@ class Metadata:
 class MetadataStore:
     def __init__(
         self,
-        metadata: Optional[Metadata] = None,
+        metadata: Metadata | None = None,
         /,
-        global_config: Optional[GlobalConfig] = None,
+        global_config: GlobalConfig | None = None,
         **kw,
     ):
         self.metadata: Metadata
@@ -128,7 +127,7 @@ class MetadataStore:
             return self.metadata.output_dir
 
     @property
-    def parent_dir(self) -> Optional[Path]:
+    def parent_dir(self) -> Path | None:
         return self.metadata.parent_dir
 
     def set_output_dir(self, path: Path):

--- a/src/cordage/util.py
+++ b/src/cordage/util.py
@@ -304,7 +304,9 @@ def to_dict(data: ConfigClass | Mapping) -> dict:
     mapping: Mapping
 
     if dataclasses.is_dataclass(data):
-        mapping = dataclasses.asdict(cast(DataclassInstance, data))
+        data = cast(ConfigClass, data)
+
+        mapping = dataclasses.asdict(data)
     else:
         mapping = cast(Mapping, data)
 

--- a/src/cordage/util.py
+++ b/src/cordage/util.py
@@ -304,7 +304,7 @@ def to_dict(data: ConfigClass | Mapping) -> dict:
     mapping: Mapping
 
     if dataclasses.is_dataclass(data):
-        mapping = dataclasses.asdict(data)
+        mapping = dataclasses.asdict(cast(DataclassInstance, data))
     else:
         mapping = cast(Mapping, data)
 

--- a/src/cordage/util.py
+++ b/src/cordage/util.py
@@ -1,18 +1,15 @@
 import dataclasses
 import logging
 import typing
-from collections.abc import Generator, Iterable, Mapping
+from collections.abc import Callable, Generator, Iterable, Mapping
 from datetime import datetime, timedelta
 from enum import Enum
 from os import PathLike
 from pathlib import Path
 from typing import (
     Any,
-    Callable,
     Literal,
-    Optional,
     TypeVar,
-    Union,
     cast,
     overload,
 )
@@ -28,7 +25,7 @@ import cordage.exceptions
 logger = logging.getLogger("cordage")
 
 
-TrialIndicesEntry = Union[tuple[Optional[int], Optional[int]], int]
+TrialIndicesEntry = tuple[int | None, int | None] | int
 TrialIndices = list[TrialIndicesEntry]
 
 
@@ -41,7 +38,7 @@ serialization_map: dict[type[Any], Callable[..., Any]] = {
 }
 
 deserialization_map: dict[type[Any], Callable[..., Any]] = {
-    datetime: lambda v: datetime.fromisoformat(v),
+    datetime: datetime.fromisoformat,
     timedelta: lambda v: timedelta(seconds=v),
 }
 
@@ -165,9 +162,9 @@ def flattened_items(
 def flattened_items(
     nested_dict: dict,
     *,
-    sep: Optional[str] = None,
+    sep: str | None = None,
     prefix: tuple[Any, ...] = (),
-) -> Generator[Union[tuple[str, Any], tuple[tuple[Any, ...], Any]], None, None]:
+) -> Generator[tuple[str, Any] | tuple[tuple[Any, ...], Any], None, None]:
     """Iter over all items in a nested dictionary."""
     for k, v in nested_dict.items():
         flat_k: tuple = (
@@ -198,7 +195,7 @@ def nested_update(target_dict: dict, update_dict: Mapping):
     return target_dict
 
 
-def nest_items(flat_items: Iterable[tuple[Union[str, tuple[Any, ...]], Any]]) -> dict[str, Any]:
+def nest_items(flat_items: Iterable[tuple[str | tuple[Any, ...], Any]]) -> dict[str, Any]:
     """Unflatten a dict.
 
     If any keys contain '.', sub-dicts will be created.
@@ -302,7 +299,7 @@ def set_nested_field(dataclass_instance, field_name: str, value: Any):
     setattr(obj, last_key, value)
 
 
-def to_dict(data: Union[ConfigClass, Mapping]) -> dict:
+def to_dict(data: ConfigClass | Mapping) -> dict:
     """Represent the fields and values of configuration as a dict."""
     mapping: Mapping
 
@@ -321,7 +318,7 @@ def to_file(dataclass_instance, path: PathLike):
 
 def config_output_dir_type(
     config_cls: type["DataclassInstance"], param_name_output_dir: str
-) -> Union[type[str], type[Path], None]:
+) -> type[str] | type[Path] | None:
     for field in dataclasses.fields(config_cls):
         if field.name == param_name_output_dir:
             if field.type in (str, "str"):

--- a/tests/config_classes.py
+++ b/tests/config_classes.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Literal
 
 
 @dataclass
@@ -54,8 +54,8 @@ class LongConfig:
     d: int = field(default=1, metadata={"help": "correct_help_text"})
     e: Literal["a", "b", "c"] = "a"
     f: bool = False
-    g: Optional[int] = None
+    g: int | None = None
     h: tuple[str, ...] = ("a", "b")
     i: tuple[str, str] = ("a", "b")
     j: tuple[str, int, float] = ("a", 1, 1.0)
-    k: Optional[int] = None
+    k: int | None = None

--- a/tests/test_field_types.py
+++ b/tests/test_field_types.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Optional, Union
 
 import pytest
 from config_classes import LongConfig as Config
@@ -111,7 +110,7 @@ def test_non_init_union_field(global_config):
     @dataclass
     class NonInitConfig:
         a: int
-        b: Union[float, int, None] = field(init=False)
+        b: float | int | None = field(init=False)
 
         def __post_init__(self):
             if self.a > 4:
@@ -163,7 +162,7 @@ def test_non_init_optional_field(global_config):
     @dataclass
     class NonInitConfig:
         a: int
-        b: Optional[float] = field(init=False)
+        b: float | None = field(init=False)
 
         def __post_init__(self):
             self.b = float(self.a)

--- a/tests/test_series_creation.py
+++ b/tests/test_series_creation.py
@@ -23,7 +23,7 @@ def test_trial_series_list(global_config, resources_path):
 
     assert series.get_changing_fields() == {("alpha", "a"), ("alpha", "b"), ("beta", "a")}
 
-    for i, t in zip(range(1, 6), trial_store):
+    for i, t in zip(range(1, 6), trial_store, strict=False):
         assert t.metadata.additional_info["trial_index"] == i
         assert t.config.alpha.a == i
         assert t.config.alpha.b == f"b{i}"
@@ -99,7 +99,7 @@ def test_partial_series_execution(global_config, resources_path, expected_trials
 
     assert len(trial_store) == len(expected_trials)
 
-    for i, t in zip(expected_trials, trial_store):
+    for i, t in zip(expected_trials, trial_store, strict=False):
         assert t.metadata.additional_info["trial_index"] == i
         assert t.config.alpha.a == i
         assert t.config.alpha.b == f"b{i}"


### PR DESCRIPTION
Python 3.9 has [reached its end of life](https://devguide.python.org/versions/). Hence, this project will no longer support it.