### PR TITLE
Improved support for literals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ python = ["3.10", "3.12", "3.14"]
 [tool.hatch.envs.lint]
 detached = true
 dependencies = [
-  "ty>=0.0.17",
+  "ty>=0.0.35",
   "ruff>=0.12.8",
 ]
 [tool.hatch.envs.lint.scripts]

--- a/src/cordage/context.py
+++ b/src/cordage/context.py
@@ -6,6 +6,7 @@ import sys
 from collections.abc import Callable, Mapping
 from contextlib import contextmanager
 from enum import Enum
+from itertools import chain
 from pathlib import Path
 from types import UnionType
 from typing import (
@@ -16,7 +17,6 @@ from typing import (
     get_args,
     get_origin,
 )
-from itertools import chain
 
 from docstring_parser import parse as parse_docstring
 
@@ -325,7 +325,7 @@ class FunctionContext(TrialIndexMixin):
                 return self._add_argument_to_parser(arg_name, args[0], help=help, **kw)
 
             elif all(get_origin(a) is Literal for a in args):
-                new_arg_type = Literal[tuple(chain(*(get_args(lit) for lit in args)))]
+                new_arg_type = Literal[tuple(chain(*(get_args(lit) for lit in args)))]  # ty: ignore[invalid-type-form]
 
                 return self._add_argument_to_parser(arg_name, new_arg_type, help=help, **kw)
 

--- a/src/cordage/context.py
+++ b/src/cordage/context.py
@@ -16,6 +16,7 @@ from typing import (
     get_args,
     get_origin,
 )
+from itertools import chain
 
 from docstring_parser import parse as parse_docstring
 
@@ -291,7 +292,7 @@ class FunctionContext(TrialIndexMixin):
             self.arg_group_config.add_argument(
                 f"--{arg_name}", type=Path, default=MISSING, help=help, metavar="PATH", **kw
             )
-            self.add_arguments_to_parser(arg_type, prefix=arg_name)
+            return self.add_arguments_to_parser(arg_type, prefix=arg_name)
 
         # Look the fields annotation to determine which type of argument
         # to add
@@ -321,7 +322,12 @@ class FunctionContext(TrialIndexMixin):
 
             if len(args) == 1:
                 # optional
-                self._add_argument_to_parser(arg_name, args[0], help=help, **kw)
+                return self._add_argument_to_parser(arg_name, args[0], help=help, **kw)
+
+            elif all(get_origin(a) is Literal for a in args):
+                new_arg_type = Literal[tuple(chain(*(get_args(lit) for lit in args)))]
+
+                return self._add_argument_to_parser(arg_name, new_arg_type, help=help, **kw)
 
             else:
                 msg = (

--- a/src/cordage/experiment.py
+++ b/src/cordage/experiment.py
@@ -45,8 +45,8 @@ if typing.TYPE_CHECKING:
 ConfigClass = TypeVar("ConfigClass", bound="DataclassInstance")
 
 
-class Experiment(Annotatable):
-    def __init__(self, *args, config_cls: type | None = None, **kwargs):
+class Experiment(Annotatable, Generic[ConfigClass]):
+    def __init__(self, *args, config_cls: type[ConfigClass] | None = None, **kwargs):
         super().__init__(*args, **kwargs)
 
         self.config_cls: type[ConfigClass] | None = config_cls
@@ -300,7 +300,7 @@ class Experiment(Annotatable):
                     tried_paths.add(path)
 
 
-class Trial(Experiment, Generic[ConfigClass]):
+class Trial(Experiment[ConfigClass]):
     def __init__(
         self,
         metadata: Metadata | None = None,
@@ -355,10 +355,14 @@ class Trial(Experiment, Generic[ConfigClass]):
                 self.metadata.configuration["output_dir"] = path
 
                 if self._config is not None:
-                    self.config.output_dir = output_dir_type(path)
+                    setattr(
+                        self.config,
+                        self.global_config.param_name_output_dir,
+                        output_dir_type(path),
+                    )
 
 
-class Series(Generic[ConfigClass], Experiment):
+class Series(Experiment[ConfigClass]):
     trials: list[Trial[ConfigClass]]
 
     def __init__(

--- a/tests/test_field_types.py
+++ b/tests/test_field_types.py
@@ -258,6 +258,7 @@ def test_string_literal_set(global_config):
     with pytest.raises(cordage.exceptions.InvalidValueError):
         cordage.run(f, ["--key", "unkown"], config_only=True, global_config=global_config)
 
+
 def test_mixed_literal(global_config):
     @dataclass
     class Config:

--- a/tests/test_field_types.py
+++ b/tests/test_field_types.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
+from typing import Literal
 
 import pytest
 from config_classes import LongConfig as Config
@@ -228,3 +229,63 @@ def test_optional(global_config):
 
     with pytest.raises(cordage.exceptions.InvalidValueError):
         cordage.run(f, ["--a", "unkown"], config_only=True, global_config=global_config)
+
+
+def test_string_literal_union(global_config):
+    @dataclass
+    class Config:
+        key: Literal["a"] | Literal["b"] | Literal["C"]
+
+    def f(config: Config):
+        assert config.key == "a"
+
+    cordage.run(f, ["--key", "a"], config_only=True, global_config=global_config)
+
+    with pytest.raises(cordage.exceptions.InvalidValueError):
+        cordage.run(f, ["--key", "unkown"], config_only=True, global_config=global_config)
+
+
+def test_string_literal_set(global_config):
+    @dataclass
+    class Config:
+        key: Literal["a", "b", "C"]
+
+    def f(config: Config):
+        assert config.key == "a"
+
+    cordage.run(f, ["--key", "a"], config_only=True, global_config=global_config)
+
+    with pytest.raises(cordage.exceptions.InvalidValueError):
+        cordage.run(f, ["--key", "unkown"], config_only=True, global_config=global_config)
+
+def test_mixed_literal(global_config):
+    @dataclass
+    class Config:
+        key: Literal["a"] | Literal[1] | Literal["c"]
+
+    def f(config: Config):
+        assert config.key == 1
+
+    cordage.run(f, ["--key", "1"], config_only=True, global_config=global_config)
+
+    def f(config: Config):
+        assert config.key == "c"
+
+    cordage.run(f, ["--key", "c"], config_only=True, global_config=global_config)
+
+    with pytest.raises(cordage.exceptions.InvalidValueError):
+        cordage.run(f, ["--a", "unkown"], config_only=True, global_config=global_config)
+
+
+def test_optional_literal(global_config):
+    @dataclass
+    class Config:
+        key: Literal["a"] | Literal["b"] | None
+
+    def f(config: Config):
+        assert config.key is None
+
+    cordage.run(f, [], config_only=True, global_config=global_config)
+
+    with pytest.raises(cordage.exceptions.InvalidValueError):
+        cordage.run(f, ["--key", "unkown"], config_only=True, global_config=global_config)

--- a/tests/test_field_types.py
+++ b/tests/test_field_types.py
@@ -266,15 +266,8 @@ def test_mixed_literal(global_config):
     def f(config: Config):
         assert config.key == 1
 
-    cordage.run(f, ["--key", "1"], config_only=True, global_config=global_config)
-
-    def f(config: Config):
-        assert config.key == "c"
-
-    cordage.run(f, ["--key", "c"], config_only=True, global_config=global_config)
-
-    with pytest.raises(cordage.exceptions.InvalidValueError):
-        cordage.run(f, ["--a", "unkown"], config_only=True, global_config=global_config)
+    with pytest.raises(TypeError):
+        cordage.run(f, ["--a", "1"], config_only=True, global_config=global_config)
 
 
 def test_optional_literal(global_config):


### PR DESCRIPTION
Previously, unions of literals (e.g., `method: Literal["a"] | Literal["b"]`) where not supported. This PR adds support for it (joining the sets of accepted literals).