### PR TITLE
Improved support for ambigous unions

### DIFF
--- a/src/cordage/context.py
+++ b/src/cordage/context.py
@@ -287,8 +287,6 @@ class FunctionContext(TrialIndexMixin):
         arg_name: str,
         arg_type: Any,
         help: str,  # noqa: A002
-        *,
-        has_default: bool,
         **kw,
     ):
         if get_origin(arg_type) is tuple:
@@ -313,16 +311,12 @@ class FunctionContext(TrialIndexMixin):
             literal_arg_type = type(choices[0])
 
             if any(not isinstance(c, literal_arg_type) for c in choices):
-                msg = f"If Literal is used, all values must be of the same type ({arg_name})."
-
-                if has_default:
-                    logger.warning(msg + " Field will be excluded from CLI options.")
-                else:
-                    msg += (
-                        " Set a default value to still use the dataclass (setting the field"
-                        " through the CLI will not be possible)."
-                    )
-                    raise TypeError(msg)
+                logger.warning(
+                    "If Literal is used, all values must be of the same type (%s). Field will be "
+                    "excluded from CLI options.",
+                    arg_name,
+                )
+                return
 
             self.arg_group_config.add_argument(
                 f"--{arg_name}",
@@ -339,26 +333,19 @@ class FunctionContext(TrialIndexMixin):
 
             if len(args) == 1:
                 # optional
-                return self._add_argument_to_parser(arg_name, args[0], help=help, has_default=has_default, **kw)
+                return self._add_argument_to_parser(arg_name, args[0], help=help, **kw)
 
             elif all(get_origin(a) is Literal for a in args):
                 new_arg_type = Literal[tuple(chain(*(get_args(lit) for lit in args)))]  # ty: ignore[invalid-type-form]
 
-                return self._add_argument_to_parser(arg_name, new_arg_type, help=help, has_default=has_default, **kw)
+                return self._add_argument_to_parser(arg_name, new_arg_type, help=help, **kw)
 
             else:
-                msg = (
-                    f"`{arg_name}` has Union annotation with more than one type (other than none)."
+                logger.warning(
+                    "`%s` has Union annotation with more than one type (other than none). Field "
+                    "will be excluded from CLI options.",
+                    arg_name,
                 )
-
-                if has_default:
-                    logger.warning(msg + " Field will be excluded from CLI options.")
-                else:
-                    msg += (
-                        " Set a default value to still use the dataclass (setting the field"
-                        " through the CLI will not be possible)."
-                    )
-                    raise TypeError(msg)
 
                 return
 
@@ -408,16 +395,12 @@ class FunctionContext(TrialIndexMixin):
             return
 
         else:
-            msg: str = f"Field `{arg_name}` us unsupported type: {arg_type}."
+            logger.warning(
+                "Field `%s` us unsupported type: %s. Field will be excluded from CLI options.",
+                arg_name,
+                str(arg_type),
+            )
 
-            if has_default:
-                logger.warning(msg + " Field will be excluded from CLI options.")
-            else:
-                msg += (
-                    " Set a default value to still use the dataclass (setting the field"
-                    " through the CLI will not be possible)."
-                )
-                raise TypeError(msg)
             return
 
     def add_arguments_to_parser(self, config_cls: type, prefix: str | None = None):
@@ -456,7 +439,6 @@ class FunctionContext(TrialIndexMixin):
             self._add_argument_to_parser(
                 arg_name,
                 field.type,
-                has_default=field.default is not dataclasses.MISSING,
                 help=help_text,
             )
 

--- a/src/cordage/context.py
+++ b/src/cordage/context.py
@@ -282,7 +282,15 @@ class FunctionContext(TrialIndexMixin):
         self.arg_group_config = self.argument_parser.add_argument_group("configuration")
         self.add_arguments_to_parser(self.main_config_cls)
 
-    def _add_argument_to_parser(self, arg_name: str, arg_type: Any, help: str, **kw):  # noqa: A002
+    def _add_argument_to_parser(
+        self,
+        arg_name: str,
+        arg_type: Any,
+        help: str,  # noqa: A002
+        *,
+        has_default: bool,
+        **kw,
+    ):
         if get_origin(arg_type) is tuple:
             arg_type = get_origin(arg_type)
 
@@ -306,7 +314,15 @@ class FunctionContext(TrialIndexMixin):
 
             if any(not isinstance(c, literal_arg_type) for c in choices):
                 msg = f"If Literal is used, all values must be of the same type ({arg_name})."
-                raise TypeError(msg)
+
+                if has_default:
+                    logger.warning(msg + " Field will be excluded from CLI options.")
+                else:
+                    msg += (
+                        " Set a default value to still use the dataclass (setting the field"
+                        " through the CLI will not be possible)."
+                    )
+                    raise TypeError(msg)
 
             self.arg_group_config.add_argument(
                 f"--{arg_name}",
@@ -316,26 +332,35 @@ class FunctionContext(TrialIndexMixin):
                 help=help,
                 **kw,
             )
+            return
 
         elif get_origin(arg_type) in (Union, UnionType):
             args = [arg for arg in get_args(arg_type) if arg is not type(None)]
 
             if len(args) == 1:
                 # optional
-                return self._add_argument_to_parser(arg_name, args[0], help=help, **kw)
+                return self._add_argument_to_parser(arg_name, args[0], help=help, has_default=has_default, **kw)
 
             elif all(get_origin(a) is Literal for a in args):
                 new_arg_type = Literal[tuple(chain(*(get_args(lit) for lit in args)))]  # ty: ignore[invalid-type-form]
 
-                return self._add_argument_to_parser(arg_name, new_arg_type, help=help, **kw)
+                return self._add_argument_to_parser(arg_name, new_arg_type, help=help, has_default=has_default, **kw)
 
             else:
                 msg = (
-                    f"Parameter `{arg_name}` could not be processed:"
-                    "Config parser does not support Union annotations with more than one type "
-                    "other than None."
+                    f"`{arg_name}` has Union annotation with more than one type (other than none)."
                 )
-                raise TypeError(msg)
+
+                if has_default:
+                    logger.warning(msg + " Field will be excluded from CLI options.")
+                else:
+                    msg += (
+                        " Set a default value to still use the dataclass (setting the field"
+                        " through the CLI will not be possible)."
+                    )
+                    raise TypeError(msg)
+
+                return
 
         # Boolean field
         elif arg_type is bool:
@@ -356,11 +381,13 @@ class FunctionContext(TrialIndexMixin):
                 help=help + " (set the value to False)",
                 **kw,
             )
+            return
 
         elif arg_type in SUPPORTED_PRIMITIVES:
             self.arg_group_config.add_argument(
                 f"--{arg_name}", type=arg_type, default=MISSING, help=help, **kw
             )
+            return
 
         elif isinstance(arg_type, type) and issubclass(arg_type, Enum):
 
@@ -378,9 +405,20 @@ class FunctionContext(TrialIndexMixin):
                 help=help,
                 choices=list(arg_type),
             )
+            return
 
         else:
-            logger.warning("Ignoring field %s: Type %s not supported.", arg_name, str(arg_type))
+            msg: str = f"Field `{arg_name}` us unsupported type: {arg_type}."
+
+            if has_default:
+                logger.warning(msg + " Field will be excluded from CLI options.")
+            else:
+                msg += (
+                    " Set a default value to still use the dataclass (setting the field"
+                    " through the CLI will not be possible)."
+                )
+                raise TypeError(msg)
+            return
 
     def add_arguments_to_parser(self, config_cls: type, prefix: str | None = None):
         """Add all fields in the (nested) config class to the parser.
@@ -415,7 +453,12 @@ class FunctionContext(TrialIndexMixin):
             # Retrieve help text
             help_text = field.metadata.get("help", param_doc.get(field.name, ""))
 
-            self._add_argument_to_parser(arg_name, field.type, help=help_text)
+            self._add_argument_to_parser(
+                arg_name,
+                field.type,
+                has_default=field.default is not dataclasses.MISSING,
+                help=help_text,
+            )
 
     def remove_missing_values(self, data: Mapping) -> dict[str, Any]:
         return {k: v for k, v in data.items() if v is not MISSING}

--- a/tests/test_field_types.py
+++ b/tests/test_field_types.py
@@ -283,3 +283,25 @@ def test_optional_literal(global_config):
 
     with pytest.raises(cordage.exceptions.InvalidValueError):
         cordage.run(f, ["--key", "unkown"], config_only=True, global_config=global_config)
+
+
+def test_union(global_config, capfd):
+    @dataclass
+    class Config:
+        ambigous_union: str | int | None = None
+        clear_union: str | None = None
+
+    def f(config: Config):
+        pass
+
+    cordage.run(f, [], config_only=True, global_config=global_config)
+
+    with pytest.raises(SystemExit):
+        cordage.run(
+            f, args=["--help"], global_config=global_config,
+        )
+
+    out, _ = capfd.readouterr()
+
+    assert "ambigous_union" not in out
+    assert "clear_union" in out

--- a/tests/test_field_types.py
+++ b/tests/test_field_types.py
@@ -262,13 +262,12 @@ def test_string_literal_set(global_config):
 def test_mixed_literal(global_config):
     @dataclass
     class Config:
-        key: Literal["a"] | Literal[1] | Literal["c"]
+        key: Literal["a"] | Literal[1] | Literal["c"] = 1
 
     def f(config: Config):
         assert config.key == 1
 
-    with pytest.raises(TypeError):
-        cordage.run(f, ["--a", "1"], config_only=True, global_config=global_config)
+    cordage.run(f, [], config_only=True, global_config=global_config)
 
 
 def test_optional_literal(global_config):
@@ -298,7 +297,9 @@ def test_union(global_config, capfd):
 
     with pytest.raises(SystemExit):
         cordage.run(
-            f, args=["--help"], global_config=global_config,
+            f,
+            args=["--help"],
+            global_config=global_config,
         )
 
     out, _ = capfd.readouterr()


### PR DESCRIPTION
In cases like the following, we cannot provide a clear CLI option, as it would be unclear, how to convert the entered value. However, the configs should still be supported without the field as a CLI-option (they will then need to be set via a config file).